### PR TITLE
Reduce user confusion about their authentication status after signin

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -17,6 +17,8 @@ use libsql::named_params;
 use nanoid::nanoid;
 use serde::Deserialize;
 
+use self::authenticated_user::AuthenticatedUser;
+
 pub(crate) mod authenticated_user;
 
 //TODO decide how long a session should live
@@ -231,16 +233,28 @@ struct SignUpTemplate {}
 #[derive(Template)]
 #[template(path = "sign_in.html")]
 struct SignInTemplate {}
-async fn sign_up_handler() -> impl IntoResponse {
+async fn sign_up_handler(user: Option<AuthenticatedUser>) -> impl IntoResponse {
+    // Check if is already authenticated and redirect to surveys
+    // Ideally they should not land on the signup page if they are already authenticated
+    if user.is_some() {
+        return Redirect::to("/surveys").into_response();
+    }
+
     let sign_up_template = SignUpTemplate {};
 
-    sign_up_template
+    sign_up_template.into_response()
 }
 
-async fn sign_in_handler() -> impl IntoResponse {
+async fn sign_in_handler(user: Option<AuthenticatedUser>) -> impl IntoResponse {
+    // Check if is already authenticated and redirect to surveys
+    // Ideally they should not land on the signin page if they are already authenticated
+    if user.is_some() {
+        return Redirect::to("/surveys").into_response();
+    }
+
     let sign_in_template = SignInTemplate {};
 
-    sign_in_template
+    sign_in_template.into_response()
 }
 
 #[derive(Template)]


### PR DESCRIPTION
Already signed in (authenticated) users opening the sign in page might be confused about their sign in status.

Reusing Authenticated user extractor from `auth/authenticated_user.rs` but if it's wrapped in an option it doesn't cause a redirect if user is not authenticated (because it is optional and axum understands that, I love axum).